### PR TITLE
Prevent repeated collision sound on floor

### DIFF
--- a/objects/obj_circle/Collision_obj_floor.gml
+++ b/objects/obj_circle/Collision_obj_floor.gml
@@ -1,1 +1,4 @@
-audio_play_sound(short_click_3, 10, false );
+if (!touching_floor) {
+    audio_play_sound(short_click_3, 10, false );
+    touching_floor = true;
+}

--- a/objects/obj_circle/Create_0.gml
+++ b/objects/obj_circle/Create_0.gml
@@ -1,3 +1,4 @@
+touching_floor = false;
 
 var fixture = physics_fixture_create();
 physics_fixture_set_circle_shape(fixture, sprite_width / 2);

--- a/objects/obj_circle/Step_0.gml
+++ b/objects/obj_circle/Step_0.gml
@@ -1,0 +1,3 @@
+if (!place_meeting(x, y, obj_floor)) {
+    touching_floor = false;
+}

--- a/objects/obj_circle/obj_circle.yy
+++ b/objects/obj_circle/obj_circle.yy
@@ -2,6 +2,7 @@
   "$GMObject":"",
   "%Name":"obj_circle",
   "eventList":[
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_goal","path":"objects/obj_goal/obj_goal.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":{"name":"obj_floor","path":"objects/obj_floor/obj_floor.yy",},"eventNum":0,"eventType":4,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},


### PR DESCRIPTION
## Summary
- track if circle is touching floor
- only play sound on first floor contact
- reset flag when leaving the floor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686012400efc8322ad3b4fbf6593ccd9