### PR TITLE
Add collision state logic

### DIFF
--- a/objects/obj_ball/Collision_obj_floor.gml
+++ b/objects/obj_ball/Collision_obj_floor.gml
@@ -1,0 +1,17 @@
+switch (collision_state)
+{
+    case CollisionState.NONE:
+    case CollisionState.EXIT:
+        collision_state = CollisionState.ENTER;
+        sprite_index = spr_enter;
+        break;
+
+    case CollisionState.ENTER:
+        collision_state = CollisionState.STAY;
+        sprite_index = spr_stay;
+        break;
+
+    case CollisionState.STAY:
+        // remain in STAY state while colliding
+        break;
+}

--- a/objects/obj_ball/Collision_obj_floor.gml
+++ b/objects/obj_ball/Collision_obj_floor.gml
@@ -3,12 +3,12 @@ switch (collision_state)
     case CollisionState.NONE:
     case CollisionState.EXIT:
         collision_state = CollisionState.ENTER;
-        sprite_index = spr_enter;
+        desired_sprite = spr_enter;
         break;
 
     case CollisionState.ENTER:
         collision_state = CollisionState.STAY;
-        sprite_index = spr_stay;
+        desired_sprite = spr_stay;
         break;
 
     case CollisionState.STAY:

--- a/objects/obj_ball/Create_0.gml
+++ b/objects/obj_ball/Create_0.gml
@@ -1,6 +1,8 @@
 
 collision_state = CollisionState.NONE;
-sprite_index = spr_circle;
+desired_sprite = spr_circle;
+sprite_index = desired_sprite;
+sprite_timer = 0;
 
 var fixture = physics_fixture_create();
 physics_fixture_set_circle_shape(fixture, sprite_width / 2);

--- a/objects/obj_ball/Create_0.gml
+++ b/objects/obj_ball/Create_0.gml
@@ -1,4 +1,7 @@
 
+collision_state = CollisionState.NONE;
+sprite_index = spr_circle;
+
 var fixture = physics_fixture_create();
 physics_fixture_set_circle_shape(fixture, sprite_width / 2);
 physics_fixture_set_density(fixture, 0.1);

--- a/objects/obj_ball/Step_0.gml
+++ b/objects/obj_ball/Step_0.gml
@@ -1,0 +1,20 @@
+var is_colliding = place_meeting(x, y, obj_floor);
+
+switch (collision_state)
+{
+    case CollisionState.STAY:
+        if (!is_colliding)
+        {
+            collision_state = CollisionState.EXIT;
+            sprite_index = spr_exit;
+        }
+        break;
+
+    case CollisionState.EXIT:
+        if (!is_colliding)
+        {
+            collision_state = CollisionState.NONE;
+            sprite_index = spr_circle;
+        }
+        break;
+}

--- a/objects/obj_ball/Step_0.gml
+++ b/objects/obj_ball/Step_0.gml
@@ -1,3 +1,10 @@
+sprite_timer += 1;
+if (sprite_timer >= room_speed)
+{
+    sprite_timer = 0;
+    sprite_index = desired_sprite;
+}
+
 var is_colliding = place_meeting(x, y, obj_floor);
 
 switch (collision_state)
@@ -6,7 +13,7 @@ switch (collision_state)
         if (!is_colliding)
         {
             collision_state = CollisionState.EXIT;
-            sprite_index = spr_exit;
+            desired_sprite = spr_exit;
         }
         break;
 
@@ -14,7 +21,7 @@ switch (collision_state)
         if (!is_colliding)
         {
             collision_state = CollisionState.NONE;
-            sprite_index = spr_circle;
+            desired_sprite = spr_circle;
         }
         break;
 }


### PR DESCRIPTION
## Summary
- track `collision_state` for `obj_ball`
- update sprite during floor collision using `CollisionState`
- handle exit and none states in the Step event

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861197c9bc88322b9182d2d5c0714af