### PR TITLE
Add persistent audio options

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1,7 +1,8 @@
+if (!variable_global_exists("music_on") || !variable_global_exists("sfx_on")) {
+    load_options();
+}
 global.game_started = false;
 global.level_complete = false;
-global.music_on = true;
-global.sfx_on = true;
 
 if (global.music_on) {
     audio_play_sound(bounce, 1, true);

--- a/objects/obj_controller/Other_3.gml
+++ b/objects/obj_controller/Other_3.gml
@@ -1,0 +1,1 @@
+save_options();

--- a/objects/obj_controller/obj_controller.yy
+++ b/objects/obj_controller/obj_controller.yy
@@ -5,6 +5,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":2,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":3,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_controller",

--- a/objects/obj_main_menu/Create_0.gml
+++ b/objects/obj_main_menu/Create_0.gml
@@ -1,8 +1,6 @@
-if (!variable_global_exists("music_on")) {
-    global.music_on = true;
-}
-if (!variable_global_exists("sfx_on")) {
-    global.sfx_on = true;
+// Load persistent audio settings the first time the menu is shown
+if (!variable_global_exists("music_on") || !variable_global_exists("sfx_on")) {
+    load_options();
 }
 if (!variable_global_exists("game_started")) {
     global.game_started = false;

--- a/objects/obj_options_menu/Step_0.gml
+++ b/objects/obj_options_menu/Step_0.gml
@@ -9,9 +9,12 @@ if (mouse_check_button_pressed(mb_left)) {
         } else {
             audio_stop_sound(bounce);
         }
+        save_options();
     } else if (point_in_rectangle(mouse_x, mouse_y, x1, 480, x2, 530)) {
         global.sfx_on = !global.sfx_on;
+        save_options();
     } else if (point_in_rectangle(mouse_x, mouse_y, x1, 580, x2, 630)) {
+        save_options();
         room_goto(MainMenuRoom);
     }
 }

--- a/pachy.yyp
+++ b/pachy.yyp
@@ -56,6 +56,7 @@
     {"id":{"name":"OptionsRoom","path":"rooms/OptionsRoom/OptionsRoom.yy",},},
     {"id":{"name":"BallState","path":"scripts/BallState/BallState.yy",},},
     {"id":{"name":"CollisionState","path":"scripts/CollisionState/CollisionState.yy",},},
+    {"id":{"name":"Options","path":"scripts/Options/Options.yy",},},
     {"id":{"name":"bounce","path":"sounds/bounce/bounce.yy",},},
     {"id":{"name":"phaser","path":"sounds/phaser/phaser.yy",},},
     {"id":{"name":"short_click_1","path":"sounds/short_click_1/short_click_1.yy",},},

--- a/scripts/Options/Options.gml
+++ b/scripts/Options/Options.gml
@@ -1,0 +1,20 @@
+function save_options() {
+    var file = "options.ini";
+    ini_open(file);
+    ini_write_string("settings", "music_on", string(global.music_on));
+    ini_write_string("settings", "sfx_on", string(global.sfx_on));
+    ini_close();
+}
+
+function load_options() {
+    var file = "options.ini";
+    if (file_exists(file)) {
+        ini_open(file);
+        global.music_on = (ini_read_string("settings", "music_on", "true") == "true");
+        global.sfx_on = (ini_read_string("settings", "sfx_on", "true") == "true");
+        ini_close();
+    } else {
+        global.music_on = true;
+        global.sfx_on = true;
+    }
+}

--- a/scripts/Options/Options.yy
+++ b/scripts/Options/Options.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"Options",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"Options",
+  "parent":{
+    "name":"Scripts",
+    "path":"folders/Scripts.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}


### PR DESCRIPTION
## Summary
- add options script with `save_options` and `load_options`
- load saved settings in the main menu
- save settings on game end
- register new script in project file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686312836618832280ef92d428a9aa93